### PR TITLE
CI/CD initial workflow & CI friendly versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,6 @@ on:
 
 jobs:
   build:
-    uses: aktin/aktin-github-scripts/workflows/maven-build-deploy.yml@main
+    uses: aktin/aktin-github-scripts/.github/workflows/maven-build-deploy.yml@main
     with:
       java-version: 11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,6 @@ on:
 
 jobs:
   build:
-    uses: aktin/aktin-github-scripts/workflows/maven-build-deploy.yml
+    uses: aktin/aktin-github-scripts/workflows/maven-build-deploy.yml@main
     with:
       java-version: 11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI/CD
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v[0-9]+.[0-9]+**
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    uses: aktin/aktin-github-scripts/workflows/maven-build-deploy.yml
+    with:
+      java-version: 11

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dwh-mail/
 .idea
 *.iml
 .vscode
+.flattened-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.aktin</groupId>
 		<artifactId>aktin</artifactId>
-		<version>0.12</version>
+		<version>${revision}</version>
 	</parent>
 
 	<scm>


### PR DESCRIPTION
Workflow implementing a combined build and deploy step. The step consist of a reusable workflow, making this PR dependent on aktin/aktin-github-scripts#2

The previously used Maven Release Plugin was replaced with [CI friendly versioning](https://maven.apache.org/maven-ci-friendly.html).